### PR TITLE
Correction du problème d'affichage des métiers de transformation (Issue #11)

### DIFF
--- a/src/pages/MetiersTransformation.js
+++ b/src/pages/MetiersTransformation.js
@@ -20,6 +20,28 @@ const MetiersTransformation = () => {
     setSelectedMetier(metier);
   };
 
+  // Format personnalisé pour afficher les valeurs avec un seul chiffre après la virgule
+  const formatNumber = (value) => {
+    return value.toFixed(1);
+  };
+
+  // Format personnalisé pour l'infobulle du graphique
+  const customTooltip = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white p-3 shadow-md rounded-md border border-gray-200">
+          <p className="font-bold text-gray-700">{label}</p>
+          <p className="text-blue-600">ETP avant IA: {formatNumber(payload[0].value)}</p>
+          <p className="text-green-600">ETP après IA: {formatNumber(payload[1].value)}</p>
+          <p className="text-gray-700 font-bold">
+            Réduction: {metiersData.etpComparaison.find(item => item.name === label)?.reduction}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
+
   return (
     <div className="space-y-8">
       <div className="flex flex-col space-y-2">
@@ -32,12 +54,25 @@ const MetiersTransformation = () => {
 
       {/* Graphique de comparaison ETP */}
       <InfoCard title="Évolution des ETP par métier">
-        <ResponsiveContainer width="100%" height={300}>
-          <BarChart data={metiersData.etpComparaison} layout="vertical">
+        <ResponsiveContainer width="100%" height={400}>
+          <BarChart 
+            data={metiersData.etpComparaison} 
+            layout="vertical"
+            margin={{ left: 120, right: 30, top: 20, bottom: 20 }}
+          >
             <CartesianGrid strokeDasharray="3 3" />
-            <XAxis type="number" domain={[0, 7]} />
-            <YAxis dataKey="name" type="category" />
-            <Tooltip />
+            <XAxis 
+              type="number" 
+              domain={[0, 7]} 
+              tickFormatter={formatNumber}
+            />
+            <YAxis 
+              dataKey="name" 
+              type="category" 
+              width={100}
+              tick={{ fontSize: 14 }}
+            />
+            <Tooltip content={customTooltip} />
             <Legend />
             <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8" />
             <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d" />


### PR DESCRIPTION
Cette PR résout l'issue #11 concernant les problèmes d'affichage dans le graphique des métiers de transformation.

**Modifications apportées :**

1. **Correction de l'affichage des noms tronqués** :
   - Augmentation de la marge gauche du graphique à 120px pour laisser plus d'espace aux libellés
   - Définition d'une largeur fixe de 100px pour l'axe Y
   - Augmentation de la taille de police des libellés pour une meilleure lisibilité

2. **Amélioration du formatage des valeurs numériques** :
   - Ajout d'une fonction `formatNumber` pour afficher les valeurs avec un seul chiffre après la virgule
   - Application de ce format aux axes et aux valeurs affichées

3. **Amélioration de l'infobulle (tooltip)** :
   - Création d'une infobulle personnalisée plus complète et lisible
   - Ajout de la valeur de réduction en pourcentage dans l'infobulle

4. **Augmentation de la hauteur du graphique** :
   - Passage de 300px à 400px pour donner plus d'espace

Ces modifications rendent le graphique plus lisible et les données plus précises.