### PR TITLE
Suppression de la branche fix-metiers-transformation-display

### DIFF
--- a/.github/delete-branch.md
+++ b/.github/delete-branch.md
@@ -1,0 +1,5 @@
+# Suppression de branche
+
+Cette PR est créée uniquement pour supprimer la branche `fix-metiers-transformation-display` qui n'est plus nécessaire.
+
+La solution pour l'issue #11 a été fusionnée à partir de la branche `fix-metiers-display-improved`.


### PR DESCRIPTION
Cette Pull Request documente la suppression de la branche `fix-metiers-transformation-display` qui n'est plus nécessaire.

La correction de l'issue #11 a été fusionnée depuis la branche `fix-metiers-display-improved` qui a proposé une solution plus robuste au problème des noms tronqués dans le graphique des métiers de transformation.

## Actions réalisées
1. Fusion de la PR #13 dans main
2. Fermeture des PR #12 et #13
3. Fermeture de l'issue #11 qui a été résolue

La branche `fix-metiers-transformation-display` peut être supprimée car elle n'est plus utile.