### PR TITLE
Fix: Correction des noms tronqués dans le graphique du dashboard (Issue #15)

### DIFF
--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
 import StatCard from '../components/StatCard';
 import InfoCard from '../components/InfoCard';
 import { metiersData } from '../data/metiersData';
@@ -9,6 +9,28 @@ import { budgetData, investissementsData } from '../data/benchmarksData';
 const Dashboard = () => {
   // Moyenne des réductions d'effectifs
   const avgReduction = Math.round((60 + 60 + 70) / 3); // Moyenne des 3 métiers avec réduction
+
+  // Format personnalisé pour afficher les valeurs avec un seul chiffre après la virgule
+  const formatNumber = (value) => {
+    return value.toFixed(1);
+  };
+
+  // Format personnalisé pour l'infobulle du graphique ETP
+  const customTooltipETP = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white p-3 shadow-md rounded-md border border-gray-200">
+          <p className="font-bold text-gray-700">{label}</p>
+          <p className="text-blue-600">ETP avant IA: {formatNumber(payload[0].value)}</p>
+          <p className="text-green-600">ETP après IA: {formatNumber(payload[1].value)}</p>
+          <p className="text-gray-700 font-bold">
+            Réduction: {metiersData.etpComparaison.find(item => item.name === label)?.reduction}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
 
   return (
     <div className="space-y-8">
@@ -51,21 +73,40 @@ const Dashboard = () => {
       {/* Graphiques principaux */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={metiersData.etpComparaison} layout="vertical">
+          <ResponsiveContainer width="100%" height={400}>
+            <BarChart 
+              data={metiersData.etpComparaison} 
+              layout="vertical"
+              margin={{ left: 200, right: 40, top: 30, bottom: 30 }}
+            >
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis type="number" domain={[0, 7]} />
-              <YAxis dataKey="name" type="category" />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8" />
-              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d" />
+              <XAxis 
+                type="number" 
+                domain={[0, 7]} 
+                tickFormatter={formatNumber}
+                label={{ value: 'Nombre d\'ETP', position: 'insideBottom', offset: -15 }}
+              />
+              <YAxis 
+                dataKey="name" 
+                type="category" 
+                width={180}
+                tick={{ fontSize: 16, fontWeight: 'bold' }}
+                tickMargin={10}
+              />
+              <Tooltip content={customTooltipETP} />
+              <Legend wrapperStyle={{ paddingTop: 20 }} />
+              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
+                <LabelList dataKey="avant" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+              </Bar>
+              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
+                <LabelList dataKey="apres" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+              </Bar>
             </BarChart>
           </ResponsiveContainer>
         </InfoCard>
 
         <InfoCard title="Évolution des budgets IT clients">
-          <ResponsiveContainer width="100%" height={300}>
+          <ResponsiveContainer width="100%" height={400}>
             <BarChart data={budgetData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />


### PR DESCRIPTION
Cette PR résout l'issue #15 concernant les noms tronqués dans le graphique "Impact sur les ETP par métier" de la page Dashboard.

## Modifications apportées

J'ai appliqué la même solution que celle utilisée pour résoudre l'issue #11 (qui concernait un problème similaire dans la page MetiersTransformation) :

1. **Solution pour les noms tronqués** :
   - Ajout d'une marge gauche de 200px pour le graphique
   - Définition d'une largeur de 180px pour l'axe Y
   - Augmentation de la taille de police à 16px et mise en gras des libellés

2. **Amélioration de la lisibilité des valeurs** :
   - Ajout d'une fonction `formatNumber` pour afficher les valeurs avec une décimale 
   - Implémentation des `LabelList` pour afficher les valeurs directement sur les barres
   - Création d'une infobulle personnalisée plus détaillée

3. **Améliorations visuelles générales** :
   - Augmentation de la hauteur du graphique de 300px à 400px
   - Ajout d'un label pour l'axe X ("Nombre d'ETP")
   - Amélioration du style de la légende

Cette correction garantit que les noms des métiers seront correctement affichés sans être tronqués, tout comme dans la page de transformation des métiers.