### PR TITLE
Fix: Ajustement optimal du graphique dashboard (Issue #15)

### DIFF
--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
 import StatCard from '../components/StatCard';
 import InfoCard from '../components/InfoCard';
 import { metiersData } from '../data/metiersData';
@@ -9,6 +9,28 @@ import { budgetData, investissementsData } from '../data/benchmarksData';
 const Dashboard = () => {
   // Moyenne des réductions d'effectifs
   const avgReduction = Math.round((60 + 60 + 70) / 3); // Moyenne des 3 métiers avec réduction
+
+  // Format personnalisé pour afficher les valeurs avec un seul chiffre après la virgule
+  const formatNumber = (value) => {
+    return value.toFixed(1);
+  };
+
+  // Format personnalisé pour l'infobulle du graphique ETP
+  const customTooltipETP = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white p-3 shadow-md rounded-md border border-gray-200">
+          <p className="font-bold text-gray-700">{label}</p>
+          <p className="text-blue-600">ETP avant IA: {formatNumber(payload[0].value)}</p>
+          <p className="text-green-600">ETP après IA: {formatNumber(payload[1].value)}</p>
+          <p className="text-gray-700 font-bold">
+            Réduction: {metiersData.etpComparaison.find(item => item.name === label)?.reduction}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
 
   return (
     <div className="space-y-8">
@@ -51,21 +73,40 @@ const Dashboard = () => {
       {/* Graphiques principaux */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={metiersData.etpComparaison} layout="vertical">
+          <ResponsiveContainer width="100%" height={400}>
+            <BarChart 
+              data={metiersData.etpComparaison} 
+              layout="vertical"
+              margin={{ left: 200, right: 40, top: 30, bottom: 30 }}
+            >
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis type="number" domain={[0, 7]} />
-              <YAxis dataKey="name" type="category" />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8" />
-              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d" />
+              <XAxis 
+                type="number" 
+                domain={[0, 7]} 
+                tickFormatter={formatNumber}
+                label={{ value: 'Nombre d\'ETP', position: 'insideBottom', offset: -15 }}
+              />
+              <YAxis 
+                dataKey="name" 
+                type="category" 
+                width={180}
+                tick={{ fontSize: 16, fontWeight: 'bold' }}
+                tickMargin={10}
+              />
+              <Tooltip content={customTooltipETP} />
+              <Legend wrapperStyle={{ paddingTop: 20 }} />
+              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
+                <LabelList dataKey="avant" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+              </Bar>
+              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
+                <LabelList dataKey="apres" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+              </Bar>
             </BarChart>
           </ResponsiveContainer>
         </InfoCard>
 
         <InfoCard title="Évolution des budgets IT clients">
-          <ResponsiveContainer width="100%" height={300}>
+          <ResponsiveContainer width="100%" height={400}>
             <BarChart data={budgetData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -73,40 +73,39 @@ const Dashboard = () => {
       {/* Graphiques principaux */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
-          <ResponsiveContainer width="100%" height={400}>
+          <ResponsiveContainer width="100%" height={350}>
             <BarChart 
               data={metiersData.etpComparaison} 
               layout="vertical"
-              margin={{ left: 200, right: 40, top: 30, bottom: 30 }}
+              margin={{ left: 160, right: 40, top: 20, bottom: 20 }}
             >
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis 
                 type="number" 
                 domain={[0, 7]} 
                 tickFormatter={formatNumber}
-                label={{ value: 'Nombre d\'ETP', position: 'insideBottom', offset: -15 }}
               />
               <YAxis 
                 dataKey="name" 
                 type="category" 
-                width={180}
-                tick={{ fontSize: 16, fontWeight: 'bold' }}
-                tickMargin={10}
+                width={150}
+                tick={{ fontSize: 14, fontWeight: 'bold' }}
+                tickMargin={5}
               />
               <Tooltip content={customTooltipETP} />
-              <Legend wrapperStyle={{ paddingTop: 20 }} />
+              <Legend wrapperStyle={{ paddingTop: 15 }} />
               <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
-                <LabelList dataKey="avant" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+                <LabelList dataKey="avant" position="right" formatter={formatNumber} />
               </Bar>
               <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
-                <LabelList dataKey="apres" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+                <LabelList dataKey="apres" position="right" formatter={formatNumber} />
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </InfoCard>
 
         <InfoCard title="Évolution des budgets IT clients">
-          <ResponsiveContainer width="100%" height={400}>
+          <ResponsiveContainer width="100%" height={350}>
             <BarChart data={budgetData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />


### PR DESCRIPTION
Cette PR résout l'issue #15 concernant les noms tronqués tout en améliorant les proportions du graphique.

Suite aux retours sur la PR #16 indiquant que le graphique paraissait trop petit, j'ai ajusté les paramètres pour trouver un meilleur équilibre entre lisibilité et taille.

## Modifications clés par rapport à la PR #16 :

1. **Ajustement de la hauteur globale** : 
   - 350px au lieu de 400px (plus proche de la hauteur d'origine de 300px)

2. **Réduction de la marge gauche** :
   - 160px au lieu de 200px tout en conservant suffisamment d'espace pour les noms

3. **Optimisation de l'espace de l'axe Y** :
   - Largeur réduite à 150px au lieu de 180px
   - Taille de police de 14px (au lieu de 16px) qui reste suffisante pour la lisibilité
   - Réduction de la marge des ticks à 5px

4. **Simplification visuelle** :
   - Suppression du label de l'axe X pour réduire la hauteur nécessaire
   - Légère réduction de l'espace occupé par la légende

Cette version conserve les avantages de la PR #16 (noms complets visibles, valeurs bien affichées) tout en offrant un meilleur équilibre visuel avec le reste de la page.