### PR TITLE
Fix: Graphiques pleine taille pour le dashboard (Issue #15)

### DIFF
--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
 import StatCard from '../components/StatCard';
 import InfoCard from '../components/InfoCard';
 import { metiersData } from '../data/metiersData';
@@ -9,6 +9,28 @@ import { budgetData, investissementsData } from '../data/benchmarksData';
 const Dashboard = () => {
   // Moyenne des réductions d'effectifs
   const avgReduction = Math.round((60 + 60 + 70) / 3); // Moyenne des 3 métiers avec réduction
+
+  // Format personnalisé pour afficher les valeurs avec un seul chiffre après la virgule
+  const formatNumber = (value) => {
+    return value.toFixed(1);
+  };
+
+  // Format personnalisé pour l'infobulle du graphique ETP
+  const customTooltipETP = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white p-3 shadow-md rounded-md border border-gray-200">
+          <p className="font-bold text-gray-700">{label}</p>
+          <p className="text-blue-600">ETP avant IA: {formatNumber(payload[0].value)}</p>
+          <p className="text-green-600">ETP après IA: {formatNumber(payload[1].value)}</p>
+          <p className="text-gray-700 font-bold">
+            Réduction: {metiersData.etpComparaison.find(item => item.name === label)?.reduction}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
 
   return (
     <div className="space-y-8">
@@ -51,21 +73,40 @@ const Dashboard = () => {
       {/* Graphiques principaux */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={metiersData.etpComparaison} layout="vertical">
+          <ResponsiveContainer width="100%" height={400}>
+            <BarChart 
+              data={metiersData.etpComparaison} 
+              layout="vertical"
+              margin={{ left: 200, right: 40, top: 30, bottom: 30 }}
+            >
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis type="number" domain={[0, 7]} />
-              <YAxis dataKey="name" type="category" />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8" />
-              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d" />
+              <XAxis 
+                type="number" 
+                domain={[0, 7]} 
+                tickFormatter={formatNumber}
+                label={{ value: 'Nombre d\'ETP', position: 'insideBottom', offset: -15 }}
+              />
+              <YAxis 
+                dataKey="name" 
+                type="category" 
+                width={180}
+                tick={{ fontSize: 16, fontWeight: 'bold' }}
+                tickMargin={10}
+              />
+              <Tooltip content={customTooltipETP} />
+              <Legend wrapperStyle={{ paddingTop: 20 }} />
+              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
+                <LabelList dataKey="avant" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+              </Bar>
+              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
+                <LabelList dataKey="apres" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+              </Bar>
             </BarChart>
           </ResponsiveContainer>
         </InfoCard>
 
         <InfoCard title="Évolution des budgets IT clients">
-          <ResponsiveContainer width="100%" height={300}>
+          <ResponsiveContainer width="100%" height={400}>
             <BarChart data={budgetData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -73,49 +73,58 @@ const Dashboard = () => {
       {/* Graphiques principaux */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
-          <ResponsiveContainer width="100%" height={350}>
-            <BarChart 
-              data={metiersData.etpComparaison} 
-              layout="vertical"
-              margin={{ left: 160, right: 40, top: 20, bottom: 20 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis 
-                type="number" 
-                domain={[0, 7]} 
-                tickFormatter={formatNumber}
-              />
-              <YAxis 
-                dataKey="name" 
-                type="category" 
-                width={150}
-                tick={{ fontSize: 14, fontWeight: 'bold' }}
-                tickMargin={5}
-              />
-              <Tooltip content={customTooltipETP} />
-              <Legend wrapperStyle={{ paddingTop: 15 }} />
-              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
-                <LabelList dataKey="avant" position="right" formatter={formatNumber} />
-              </Bar>
-              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
-                <LabelList dataKey="apres" position="right" formatter={formatNumber} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          {/* Augmentons la hauteur pour mieux remplir l'encart */}
+          <div style={{ height: '450px' }} className="w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart 
+                data={metiersData.etpComparaison} 
+                layout="vertical"
+                margin={{ left: 160, right: 50, top: 20, bottom: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis 
+                  type="number" 
+                  domain={[0, 7]} 
+                  tickFormatter={formatNumber}
+                />
+                <YAxis 
+                  dataKey="name" 
+                  type="category" 
+                  width={150}
+                  tick={{ fontSize: 14, fontWeight: 'bold' }}
+                  tickMargin={5}
+                />
+                <Tooltip content={customTooltipETP} />
+                <Legend wrapperStyle={{ paddingTop: 15 }} />
+                <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
+                  <LabelList dataKey="avant" position="right" formatter={formatNumber} />
+                </Bar>
+                <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
+                  <LabelList dataKey="apres" position="right" formatter={formatNumber} />
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </InfoCard>
 
         <InfoCard title="Évolution des budgets IT clients">
-          <ResponsiveContainer width="100%" height={350}>
-            <BarChart data={budgetData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 40]} />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="avant" name="Avant IA (%)" fill="#8884d8" />
-              <Bar dataKey="apres" name="Après IA (%)" fill="#82ca9d" />
-            </BarChart>
-          </ResponsiveContainer>
+          {/* Augmentons aussi cette hauteur pour la cohérence */}
+          <div style={{ height: '450px' }} className="w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart 
+                data={budgetData}
+                margin={{ left: 10, right: 10, top: 20, bottom: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis domain={[0, 40]} />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="avant" name="Avant IA (%)" fill="#8884d8" />
+                <Bar dataKey="apres" name="Après IA (%)" fill="#82ca9d" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </InfoCard>
       </div>
 

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -73,40 +73,39 @@ const Dashboard = () => {
       {/* Graphiques principaux */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
-          <ResponsiveContainer width="100%" height={400}>
+          <ResponsiveContainer width="100%" height={350}>
             <BarChart 
               data={metiersData.etpComparaison} 
               layout="vertical"
-              margin={{ left: 200, right: 40, top: 30, bottom: 30 }}
+              margin={{ left: 160, right: 40, top: 20, bottom: 20 }}
             >
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis 
                 type="number" 
                 domain={[0, 7]} 
                 tickFormatter={formatNumber}
-                label={{ value: 'Nombre d\'ETP', position: 'insideBottom', offset: -15 }}
               />
               <YAxis 
                 dataKey="name" 
                 type="category" 
-                width={180}
-                tick={{ fontSize: 16, fontWeight: 'bold' }}
-                tickMargin={10}
+                width={150}
+                tick={{ fontSize: 14, fontWeight: 'bold' }}
+                tickMargin={5}
               />
               <Tooltip content={customTooltipETP} />
-              <Legend wrapperStyle={{ paddingTop: 20 }} />
+              <Legend wrapperStyle={{ paddingTop: 15 }} />
               <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
-                <LabelList dataKey="avant" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+                <LabelList dataKey="avant" position="right" formatter={formatNumber} />
               </Bar>
               <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
-                <LabelList dataKey="apres" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+                <LabelList dataKey="apres" position="right" formatter={formatNumber} />
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </InfoCard>
 
         <InfoCard title="Évolution des budgets IT clients">
-          <ResponsiveContainer width="100%" height={400}>
+          <ResponsiveContainer width="100%" height={350}>
             <BarChart data={budgetData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />


### PR DESCRIPTION
Cette PR propose une nouvelle amélioration pour l'issue #15, en maximisant la taille des graphiques pour qu'ils remplissent mieux les encarts tout en conservant la lisibilité des noms.

Suite à vos retours indiquant que le graphique paraissait encore trop petit par rapport à l'encart, j'ai effectué les modifications suivantes :

## Principales améliorations :

1. **Utilisation d'une hauteur fixe plus importante** :
   - Passage à une hauteur fixe de 450px définie directement par style
   - Utilisation de 100% de la hauteur et largeur disponibles dans le conteneur

2. **Meilleure approche pour le sizing des graphiques** :
   - Abandon de l'approche par hauteur définie dans ResponsiveContainer
   - Utilisation d'un div conteneur avec hauteur fixe et ResponsiveContainer à 100%
   - Cette méthode permet un meilleur contrôle sur les dimensions finales

3. **Ajustements des marges pour les deux graphiques** :
   - Graphique ETP : marges adaptées (160px à gauche, 50px à droite)
   - Graphique des budgets IT : ajout de marges explicites pour cohérence

4. **Maintien des améliorations précédentes** :
   - Conservation de l'espace suffisant pour les libellés (150px)
   - Noms toujours complètement visibles
   - Lisibilité des valeurs grâce aux libellés sur les barres

Ces modifications permettent d'obtenir des graphiques beaucoup plus grands qui remplissent correctement les encarts, tout en conservant la lisibilité des noms et des valeurs.