### PR TITLE
Fix: Marge gauche à 0 pour maximiser l'espace (Issue #15)

### DIFF
--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, LabelList } from 'recharts';
 import StatCard from '../components/StatCard';
 import InfoCard from '../components/InfoCard';
 import { metiersData } from '../data/metiersData';
@@ -9,6 +9,28 @@ import { budgetData, investissementsData } from '../data/benchmarksData';
 const Dashboard = () => {
   // Moyenne des réductions d'effectifs
   const avgReduction = Math.round((60 + 60 + 70) / 3); // Moyenne des 3 métiers avec réduction
+
+  // Format personnalisé pour afficher les valeurs avec un seul chiffre après la virgule
+  const formatNumber = (value) => {
+    return value.toFixed(1);
+  };
+
+  // Format personnalisé pour l'infobulle du graphique ETP
+  const customTooltipETP = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white p-3 shadow-md rounded-md border border-gray-200">
+          <p className="font-bold text-gray-700">{label}</p>
+          <p className="text-blue-600">ETP avant IA: {formatNumber(payload[0].value)}</p>
+          <p className="text-green-600">ETP après IA: {formatNumber(payload[1].value)}</p>
+          <p className="text-gray-700 font-bold">
+            Réduction: {metiersData.etpComparaison.find(item => item.name === label)?.reduction}
+          </p>
+        </div>
+      );
+    }
+    return null;
+  };
 
   return (
     <div className="space-y-8">
@@ -51,21 +73,40 @@ const Dashboard = () => {
       {/* Graphiques principaux */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
-          <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={metiersData.etpComparaison} layout="vertical">
+          <ResponsiveContainer width="100%" height={400}>
+            <BarChart 
+              data={metiersData.etpComparaison} 
+              layout="vertical"
+              margin={{ left: 200, right: 40, top: 30, bottom: 30 }}
+            >
               <CartesianGrid strokeDasharray="3 3" />
-              <XAxis type="number" domain={[0, 7]} />
-              <YAxis dataKey="name" type="category" />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8" />
-              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d" />
+              <XAxis 
+                type="number" 
+                domain={[0, 7]} 
+                tickFormatter={formatNumber}
+                label={{ value: 'Nombre d\'ETP', position: 'insideBottom', offset: -15 }}
+              />
+              <YAxis 
+                dataKey="name" 
+                type="category" 
+                width={180}
+                tick={{ fontSize: 16, fontWeight: 'bold' }}
+                tickMargin={10}
+              />
+              <Tooltip content={customTooltipETP} />
+              <Legend wrapperStyle={{ paddingTop: 20 }} />
+              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
+                <LabelList dataKey="avant" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+              </Bar>
+              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
+                <LabelList dataKey="apres" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+              </Bar>
             </BarChart>
           </ResponsiveContainer>
         </InfoCard>
 
         <InfoCard title="Évolution des budgets IT clients">
-          <ResponsiveContainer width="100%" height={300}>
+          <ResponsiveContainer width="100%" height={400}>
             <BarChart data={budgetData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -73,49 +73,58 @@ const Dashboard = () => {
       {/* Graphiques principaux */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
-          <ResponsiveContainer width="100%" height={350}>
-            <BarChart 
-              data={metiersData.etpComparaison} 
-              layout="vertical"
-              margin={{ left: 160, right: 40, top: 20, bottom: 20 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis 
-                type="number" 
-                domain={[0, 7]} 
-                tickFormatter={formatNumber}
-              />
-              <YAxis 
-                dataKey="name" 
-                type="category" 
-                width={150}
-                tick={{ fontSize: 14, fontWeight: 'bold' }}
-                tickMargin={5}
-              />
-              <Tooltip content={customTooltipETP} />
-              <Legend wrapperStyle={{ paddingTop: 15 }} />
-              <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
-                <LabelList dataKey="avant" position="right" formatter={formatNumber} />
-              </Bar>
-              <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
-                <LabelList dataKey="apres" position="right" formatter={formatNumber} />
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          {/* Augmentons la hauteur pour mieux remplir l'encart */}
+          <div style={{ height: '450px' }} className="w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart 
+                data={metiersData.etpComparaison} 
+                layout="vertical"
+                margin={{ left: 160, right: 50, top: 20, bottom: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis 
+                  type="number" 
+                  domain={[0, 7]} 
+                  tickFormatter={formatNumber}
+                />
+                <YAxis 
+                  dataKey="name" 
+                  type="category" 
+                  width={150}
+                  tick={{ fontSize: 14, fontWeight: 'bold' }}
+                  tickMargin={5}
+                />
+                <Tooltip content={customTooltipETP} />
+                <Legend wrapperStyle={{ paddingTop: 15 }} />
+                <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
+                  <LabelList dataKey="avant" position="right" formatter={formatNumber} />
+                </Bar>
+                <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
+                  <LabelList dataKey="apres" position="right" formatter={formatNumber} />
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </InfoCard>
 
         <InfoCard title="Évolution des budgets IT clients">
-          <ResponsiveContainer width="100%" height={350}>
-            <BarChart data={budgetData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis domain={[0, 40]} />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="avant" name="Avant IA (%)" fill="#8884d8" />
-              <Bar dataKey="apres" name="Après IA (%)" fill="#82ca9d" />
-            </BarChart>
-          </ResponsiveContainer>
+          {/* Augmentons aussi cette hauteur pour la cohérence */}
+          <div style={{ height: '450px' }} className="w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart 
+                data={budgetData}
+                margin={{ left: 10, right: 10, top: 20, bottom: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis domain={[0, 40]} />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="avant" name="Avant IA (%)" fill="#8884d8" />
+                <Bar dataKey="apres" name="Après IA (%)" fill="#82ca9d" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </InfoCard>
       </div>
 

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -73,40 +73,39 @@ const Dashboard = () => {
       {/* Graphiques principaux */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
-          <ResponsiveContainer width="100%" height={400}>
+          <ResponsiveContainer width="100%" height={350}>
             <BarChart 
               data={metiersData.etpComparaison} 
               layout="vertical"
-              margin={{ left: 200, right: 40, top: 30, bottom: 30 }}
+              margin={{ left: 160, right: 40, top: 20, bottom: 20 }}
             >
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis 
                 type="number" 
                 domain={[0, 7]} 
                 tickFormatter={formatNumber}
-                label={{ value: 'Nombre d\'ETP', position: 'insideBottom', offset: -15 }}
               />
               <YAxis 
                 dataKey="name" 
                 type="category" 
-                width={180}
-                tick={{ fontSize: 16, fontWeight: 'bold' }}
-                tickMargin={10}
+                width={150}
+                tick={{ fontSize: 14, fontWeight: 'bold' }}
+                tickMargin={5}
               />
               <Tooltip content={customTooltipETP} />
-              <Legend wrapperStyle={{ paddingTop: 20 }} />
+              <Legend wrapperStyle={{ paddingTop: 15 }} />
               <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
-                <LabelList dataKey="avant" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+                <LabelList dataKey="avant" position="right" formatter={formatNumber} />
               </Bar>
               <Bar dataKey="apres" name="ETP après IA" fill="#82ca9d">
-                <LabelList dataKey="apres" position="right" formatter={formatNumber} style={{ fontWeight: 'bold' }} />
+                <LabelList dataKey="apres" position="right" formatter={formatNumber} />
               </Bar>
             </BarChart>
           </ResponsiveContainer>
         </InfoCard>
 
         <InfoCard title="Évolution des budgets IT clients">
-          <ResponsiveContainer width="100%" height={400}>
+          <ResponsiveContainer width="100%" height={350}>
             <BarChart data={budgetData}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="name" />

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -79,7 +79,7 @@ const Dashboard = () => {
               <BarChart 
                 data={metiersData.etpComparaison} 
                 layout="vertical"
-                margin={{ left: 150, right: 30, top: 10, bottom: 10 }}
+                margin={{ left: 0, right: 30, top: 10, bottom: 10 }}
               >
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis 
@@ -91,8 +91,8 @@ const Dashboard = () => {
                 <YAxis 
                   dataKey="name" 
                   type="category" 
-                  width={140}
-                  tick={{ fontSize: 14, fontWeight: 'bold' }}
+                  width={105}
+                  tick={{ fontSize: 12, fontWeight: 'bold' }}
                   tickMargin={5}
                 />
                 <Tooltip content={customTooltipETP} />
@@ -117,7 +117,7 @@ const Dashboard = () => {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart 
                 data={budgetData}
-                margin={{ left: 5, right: 5, top: 10, bottom: 10 }}
+                margin={{ left: 0, right: 5, top: 10, bottom: 10 }}
               >
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="name" tick={{ fontSize: 12 }} />

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -74,28 +74,32 @@ const Dashboard = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <InfoCard title="Impact sur les ETP par métier">
           {/* Augmentons la hauteur pour mieux remplir l'encart */}
-          <div style={{ height: '450px' }} className="w-full">
+          <div style={{ height: '480px', width: '100%', padding: '0', margin: '0' }} className="w-full">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart 
                 data={metiersData.etpComparaison} 
                 layout="vertical"
-                margin={{ left: 160, right: 50, top: 20, bottom: 20 }}
+                margin={{ left: 150, right: 30, top: 10, bottom: 10 }}
               >
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis 
                   type="number" 
                   domain={[0, 7]} 
                   tickFormatter={formatNumber}
+                  fontSize={12}
                 />
                 <YAxis 
                   dataKey="name" 
                   type="category" 
-                  width={150}
+                  width={140}
                   tick={{ fontSize: 14, fontWeight: 'bold' }}
                   tickMargin={5}
                 />
                 <Tooltip content={customTooltipETP} />
-                <Legend wrapperStyle={{ paddingTop: 15 }} />
+                <Legend 
+                  wrapperStyle={{ paddingTop: 5 }} 
+                  height={25}
+                />
                 <Bar dataKey="avant" name="ETP avant IA" fill="#8884d8">
                   <LabelList dataKey="avant" position="right" formatter={formatNumber} />
                 </Bar>
@@ -109,17 +113,17 @@ const Dashboard = () => {
 
         <InfoCard title="Évolution des budgets IT clients">
           {/* Augmentons aussi cette hauteur pour la cohérence */}
-          <div style={{ height: '450px' }} className="w-full">
+          <div style={{ height: '480px', width: '100%', padding: '0', margin: '0' }} className="w-full">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart 
                 data={budgetData}
-                margin={{ left: 10, right: 10, top: 20, bottom: 20 }}
+                margin={{ left: 5, right: 5, top: 10, bottom: 10 }}
               >
                 <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="name" />
-                <YAxis domain={[0, 40]} />
+                <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                <YAxis domain={[0, 40]} tick={{ fontSize: 12 }} />
                 <Tooltip />
-                <Legend />
+                <Legend height={25} wrapperStyle={{ paddingTop: 5 }} />
                 <Bar dataKey="avant" name="Avant IA (%)" fill="#8884d8" />
                 <Bar dataKey="apres" name="Après IA (%)" fill="#82ca9d" />
               </BarChart>


### PR DESCRIPTION
Cette PR propose une solution radicale pour l'issue #15, en réduisant la marge gauche à 0 pour maximiser pleinement l'espace horizontal disponible.

## Améliorations clés par rapport à la PR #19 :

1. **Marge gauche à 0** :
   - Réduction complète de la marge gauche à 0px (contre 150px précédemment)
   - Espace horizontal maximisé pour les barres du graphique

2. **Adaptations pour maintenir la lisibilité** :
   - Largeur de l'axe Y réduite à 105px (contre 140px précédemment)
   - Taille de police des étiquettes légèrement réduite (12px)
   - Conservation de la mise en gras pour assurer la lisibilité

3. **Optimisation des autres graphiques** :
   - Application du même principe au graphique des budgets IT (marge gauche à 0)
   - Cohérence visuelle entre les deux graphiques

Cette approche radicale permet de maximiser totalement l'espace horizontal disponible tout en conservant la lisibilité des noms de métiers, offrant ainsi un graphique pleinement adapté à l'encart dans lequel il se trouve.